### PR TITLE
Mesh's addSubMesh() method changed to protected.

### DIFF
--- a/src/away3d/entities/Mesh.as
+++ b/src/away3d/entities/Mesh.as
@@ -255,7 +255,7 @@
 		/**
 		 * Adds a SubMesh wrapping a SubGeometry.
 		 */
-		private function addSubMesh(subGeometry : SubGeometry) : void
+		protected function addSubMesh(subGeometry : SubGeometry) : void
 		{
 			var subMesh : SubMesh = new SubMesh(subGeometry, this, null);
 			var len : uint = _subMeshes.length;


### PR DESCRIPTION
My merger sponge primitive needs to use more than 1 vertex buffer. It
extends PrimitiveBase and hence Mesh. Having addSubMesh() be protected
instead of private, extending primitives like this one can use multiple
buffers. It could be arcane also.
