### PR TITLE
ColladaParser

### DIFF
--- a/src/away3d/loaders/parsers/ColladaParser.as
+++ b/src/away3d/loaders/parsers/ColladaParser.as
@@ -408,7 +408,7 @@ package away3d.loaders.parsers {
 			}else {
 				o = new ObjectContainer3D();
 			}
-
+			
 			o.name = node.attribute("name").toString();
 			_transform = o.transform;
 			_parent.addChild(o);
@@ -468,6 +468,9 @@ package away3d.loaders.parsers {
 						return;
 				}//switch
 			}//for
+			if(o.assetType == AssetType.CONTAINER){
+				finalizeAsset(o, o.name);
+			}
 		}//parseNode
 	}//class
 }//package


### PR DESCRIPTION
This fork provides an import functionality of COLLADA files for the Away3D 4.0 engine. The motivation was to load the hierarchical structure and the geometries of objects that are modeled in CINEMA 4D and exported as COLLADA file. 

supported features:
-up_axis
-global scale factor
-asynchron and fast
geomerty
-mesh (Vertex, Normal, Texcoord)
-only polylist
visualscene
-only one scene
-translate
-rotate
-hierarchy

tested with Collada export from CINEMA 4D R11.021
