### PR TITLE
Fixed removeSegment issue in SegmentSet

### DIFF
--- a/src/away3d/entities/SegmentSet.as
+++ b/src/away3d/entities/SegmentSet.as
@@ -155,6 +155,7 @@
 			var index : uint;
 			for (var i : uint = 0; i < _segments.length; ++i) {
 				if (_segments[i] == segment) {
+					segment.segmentsBase = null;
 					_segments.splice(i, 1);
 					removeSegmentByIndex(segment.index);
 					_lineCount--;


### PR DESCRIPTION
Fixed bug where LineSegments that have previously been removed from a SegmentSet still attempt to update the SegmentSet when their start or end vector is set (which in turn screws up the internal indexing of the SegmentSet).
