### PR TITLE
Default value for ColorMaterial.color

### DIFF
--- a/src/away3d/materials/ColorMaterial.as
+++ b/src/away3d/materials/ColorMaterial.as
@@ -16,7 +16,7 @@ package away3d.materials
 		 * @param color The material's diffuse surface color.
 		 * @param alpha The material's surface alpha.
 		 */
-		public function ColorMaterial(color : uint, alpha : Number = 1)
+		public function ColorMaterial(color : uint = 0xcccccc, alpha : Number = 1)
 		{
 			super();
 			this.color = color;


### PR DESCRIPTION
please consider a useful default for ColorMaterial.color in the constructor.

i used 0xcccccc; an 80% grey that leaves room for specular highlights before the lighting blows out.

this is taking a cue from the x3d spec (http://www.web3d.org/files/specifications/19775-1/V3.2/Part01/components/shape.html#Material)
