### PR TITLE
Update src/away3d/containers/View3D.as

### DIFF
--- a/src/away3d/containers/View3D.as
+++ b/src/away3d/containers/View3D.as
@@ -600,6 +600,7 @@
 			if (_filter3DRenderer && _stage3DProxy._context3D) {
 				_renderer.render(_entityCollector, _filter3DRenderer.getMainInputTexture(_stage3DProxy), _rttBufferManager.renderToTextureRect);
 				_filter3DRenderer.render(_stage3DProxy, camera, _depthRender);
+				_renderer.shareContext = false;
 			} else {
 				_renderer.shareContext = _shareContext;
 				if (_shareContext)


### PR DESCRIPTION
In multilayering when turning on filter3d on the fly, renderer still work in shareContext = true and make an Error:  Error: Error #3692:For each frame buffers must be cleared before render.

github discussion thread: https://github.com/away3d/away3d-core-fp11/issues/381
