### PR TITLE
AWD2Parser does not correctly parse ColorMaterials

### DIFF
--- a/src/away3d/loaders/parsers/AWD2Parser.as
+++ b/src/away3d/loaders/parsers/AWD2Parser.as
@@ -384,9 +384,11 @@ package away3d.loaders.parsers
 			
 			if (type == 1) { // Color material
 				var color : uint;
-				
-				color = props.get(1, 0xcccccc);
-				mat = new ColorMaterial(color, props.get(10, 1.0));
+				var alpha : Number;
+				color = (props.get(1, 0xccccccff) >> 8) & 0xffffff;
+				alpha = Number(props.get(1, 0xccccccff) & 0xff) / 255.0;
+				mat = new ColorMaterial(color, alpha);
+				finalize = true;
 			}
 			else if (type == 2) { // Bitmap material
 				//TODO: not used


### PR DESCRIPTION
There are two issues when AWD2Parser.as extracts ColorMaterial information (line 384).

First, if (type == 1) "ColorMaterial", the finalize variable is never initialized, which means finalizeAsset() is called randomly.

Secondly, again in the "ColorMaterial" flow, the RGBA color variable is incorrectly decoded.
AWD2 encodes color as RGBA while ColorMaterial uses separate color and alpha values.
