### PR TITLE
Update AWD2.1 + AssetEvent + bugfix

### DIFF
--- a/src/away3d/events/AssetEvent.as
+++ b/src/away3d/events/AssetEvent.as
@@ -22,6 +22,8 @@ package away3d.events
 		public static const SEGMENT_SET_COMPLETE : String = "segmentSetComplete";
 		public static const LIGHT_COMPLETE : String = "lightComplete";
 		public static const LIGHTPICKER_COMPLETE : String = "lightPickerComplete";
+		public static const EFFECTMETHOD_COMPLETE : String = "effectMethodComplete";
+		public static const SHADOWMAPMETHOD_COMPLETE : String = "shadowMapMethodComplete";
 		
 		public static const ASSET_RENAME : String = 'assetRename';
 		public static const ASSET_CONFLICT_RESOLVED : String = 'assetConflictResolved';

--- a/src/away3d/loaders/parsers/ParserBase.as
+++ b/src/away3d/loaders/parsers/ParserBase.as
@@ -303,7 +303,7 @@ package away3d.loaders.parsers
 		arcane function resumeParsingAfterDependencies() : void
 		{
 			_parsingPaused = false;
-			_timer.start();
+			if (_timer){	_timer.start();}
 		}
 		
 		
@@ -376,6 +376,14 @@ package away3d.loaders.parsers
 				case AssetType.SEGMENT_SET:
 					type_name = 'segmentSet';
 					type_event = AssetEvent.SEGMENT_SET_COMPLETE;
+					break;
+				case AssetType.EFFECTS_METHOD:
+					type_name = 'effectsMethod';
+					type_event = AssetEvent.EFFECTMETHOD_COMPLETE;
+					break;
+				case AssetType.SHADOW_MAP_METHOD:
+					type_name = 'effectsMethod';
+					type_event = AssetEvent.SHADOWMAPMETHOD_COMPLETE;
 					break;
 				default:
 					throw new Error('Unhandled asset type '+asset.assetType+'. Report as bug!');


### PR DESCRIPTION
next update 2.1
added AssetEvents for ShadowMapMethod and EffectMethod

if the last AWDBlock of a AWDFile is a TextureBlock, the parser will through a Error at
ParserBase.as line306. 
This happens because the parserBase.as tries to execute _Timer.start(), while _timer is not defined anymore.
For now i just added the test - if _Timer exists -, but i do not know if this might not end up with trouble in other parsers etc.
