### PR TITLE
Disposed View3D should not listen to VIEWPORT_UPDATED event anymore.

### DIFF
--- a/src/away3d/containers/View3D.as
+++ b/src/away3d/containers/View3D.as
@@ -785,6 +785,7 @@
 		 */
 		public function dispose() : void
 		{
+			_stage3DProxy.removeEventListener(Stage3DEvent.VIEWPORT_UPDATED, onViewportUpdated);
 			if (!shareContext) {
 				_stage3DProxy.dispose();
 			}


### PR DESCRIPTION
Bug found in shared context environment, while playing with fullscreen toggle and disposable views.
