### PR TITLE
Extend LookAtController to allow 'upAxis' to be defined.

### DIFF
--- a/src/away3d/controllers/LookAtController.as
+++ b/src/away3d/controllers/LookAtController.as
@@ -1,4 +1,4 @@
-﻿package away3d.controllers
+package away3d.controllers
 {
 	import away3d.containers.*;
 	import away3d.entities.*;
@@ -16,6 +16,7 @@
         protected var _lookAtPosition:Vector3D;
         protected var _lookAtObject:ObjectContainer3D;
 		protected var _origin:Vector3D = new Vector3D(0.0,0.0,0.0);
+		protected var _upAxis:Vector3D = Vector3D.Y_AXIS;
 
 		/**
 		 * Creates a new <code>LookAtController</code> object.
@@ -28,6 +29,21 @@
 				this.lookAtObject = lookAtObject;
 			else
 				this.lookAtPosition = new Vector3D();
+		}
+
+		/**
+        * The vector representing the up direction of the target object.
+        */
+		public function get upAxis():Vector3D
+		{
+			return _upAxis;
+		}
+		
+		public function set upAxis(upAxis:Vector3D):void
+		{
+			_upAxis = upAxis;
+			
+			notifyUpdate();
 		}
 
 		/**
@@ -85,9 +101,9 @@
 			if (_targetObject) {
 				
 				if(_lookAtPosition) {
-					_targetObject.lookAt(_lookAtPosition);
+					_targetObject.lookAt(_lookAtPosition, _upAxis);
 				} else if (_lookAtObject) {
-					_targetObject.lookAt(_lookAtObject.scene ? _lookAtObject.scenePosition : _lookAtObject.position);
+					_targetObject.lookAt(_lookAtObject.scene ? _lookAtObject.scenePosition : _lookAtObject.position, _upAxis);
 				}
 			}
 		}


### PR DESCRIPTION
LookAtController (and by implication HoverController) assumes that up is in the +Y direction. The purpose of this pull request is to allow the up direction to be set by the user of these classes.

This request should have no net effect unless the 'upAxis' property is modified.
