### PR TITLE
It fix issue 577

### DIFF
--- a/src/away3d/materials/methods/ShaderMethodSetup.as
+++ b/src/away3d/materials/methods/ShaderMethodSetup.as
@@ -230,6 +230,9 @@ package away3d.materials.methods {
 
 		public function getMethodAt(index : int) : EffectMethodBase
 		{
+			if (!_methods.length)
+				return null;
+			
 			return EffectMethodBase(_methods[index].method);
 		}
 


### PR DESCRIPTION
It fix https://github.com/away3d/away3d-core-fp11/issues/577

If i want to know is material have any methods and try do it like this:
getMethodAt(0), i will catch error because of:
ShaderMethodSetup.getMethodAt { return
EffectMethodBase(_methods[index].method); }

It should check _methods length and return null if legnth is 0
