### PR TITLE
Added a material which renders silhouettes over obstructing objects.

### DIFF
--- a/src/away3d/materials/SilhouetteMaterial.as
+++ b/src/away3d/materials/SilhouetteMaterial.as
@@ -1,0 +1,91 @@
+package away3d.materials 
+{
+	import away3d.arcane;
+	import away3d.materials.passes.SilhouetteMaterialPass;
+	import flash.display3D.Context3D;
+	
+	use namespace arcane;
+	
+	/**
+	 * ...
+	 * @author Max Knoblich
+	 */
+	public class SilhouetteMaterial extends ColorMaterial 
+	{
+		private var _silhouettePass:SilhouetteMaterialPass;
+		
+		/**
+		 * Creates a new ColorMaterial object.
+		 * @param color The material's diffuse surface color.
+		 * @param alpha The material's surface alpha.
+		 */
+		public function SilhouetteMaterial(color : uint = 0xcccccc, silhouetteColor:uint = 0x0099FF, alpha : Number = 1, silhouetteAlpha : Number = 0.5) 
+		{
+			super(color, alpha);
+			
+			_silhouettePass = new SilhouetteMaterialPass(this);
+			_silhouettePass.diffuseMethod.diffuseColor = silhouetteColor;
+			
+			this.silhouetteAlpha = silhouetteAlpha;
+			
+			clearPasses();
+			addPass(_silhouettePass);
+			addPass(_screenPass);
+			
+			_renderOrderId = 1;
+		}
+		
+		/**
+		 * The color of the silhouette which is rendered behind obstructing objects.
+		 */
+		public function get silhouetteColor():uint 
+		{
+			return _silhouettePass.diffuseMethod.diffuseColor;
+		}
+		
+		public function set silhouetteColor(value:uint):void 
+		{
+			_silhouettePass.diffuseMethod.diffuseColor = value;
+		}
+		
+		/**
+		 * The alpha of the silhouette which is rendered behind obstructing objects.
+		 */
+		public function get silhouetteAlpha() : Number
+		{
+			return _silhouettePass.diffuseMethod.diffuseAlpha;
+		}
+
+		public function set silhouetteAlpha(value : Number) : void
+		{
+			if (value > 1) value = 1;
+			else if (value < 0) value = 0;
+			_silhouettePass.diffuseMethod.diffuseAlpha = value;
+		}
+		
+		override public function get requiresBlending():Boolean 
+		{
+			return true;
+		}
+		
+		override arcane function updateMaterial(context:Context3D):void
+		{
+			if (_screenPass._passesDirty)
+			{
+				clearPasses();
+				if (_screenPass._passes)
+				{
+					var len:uint = _screenPass._passes.length;
+					for (var i:uint = 0; i < len; ++i)
+						addPass(_screenPass._passes[i]);
+				}
+				
+				addPass(_screenPass);
+				addPass(_silhouettePass);
+				_screenPass._passesDirty = false;
+			}
+		}
+		
+	}
+
+}

--- a/src/away3d/materials/passes/SilhouetteMaterialPass.as
+++ b/src/away3d/materials/passes/SilhouetteMaterialPass.as
@@ -1,0 +1,34 @@
+package away3d.materials.passes
+{
+	import away3d.arcane;
+	import away3d.cameras.Camera3D;
+	import away3d.core.managers.Stage3DProxy;
+	import away3d.materials.MaterialBase;
+	import flash.display3D.Context3DCompareMode;
+	
+	use namespace arcane;
+	
+	/**
+	 * ...
+	 * @author Max Knoblich
+	 */
+	public class SilhouetteMaterialPass extends DefaultScreenPass
+	{
+		/**
+		 * Creates a new SilhouetteMaterialPass objects.
+		 */
+		public function SilhouetteMaterialPass(material:MaterialBase)
+		{
+			super(material);
+			_depthCompareMode = Context3DCompareMode.GREATER;
+		}
+		
+		override arcane function activate(stage3DProxy:Stage3DProxy, camera:Camera3D, textureRatioX:Number, textureRatioY:Number):void
+		{
+			super.activate(stage3DProxy, camera, textureRatioX, textureRatioY);
+			stage3DProxy._context3D.setDepthTest(false, _depthCompareMode);
+		}
+	
+	}
+
+}


### PR DESCRIPTION
- added SilhouetteMaterial.as. SilhouetteMaterial uses SilhouetteMaterialPass.as to first render the silhouette over obstructing objects, then the actual object. SilhouetteMaterial.as currently extends ColorMaterial.
- added SilhouetteMaterialPass.as. SilhouetteMaterialPass sets the compare mode to GREATER in the activate function and prevents the pass to write into the depth buffer.

**[Preview of the Effect](http://www.max-did-it.com/projects/silhouette/)**

This effect is based on the method described in: [Rendering Silhouettes For Concealed Objects](http://www.max-did-it.com/index.php/2013/02/25/rendering-silhouettes-for-concealed-objects/)

The section about using the effect with Away3D in the article is inaccurate. I wrote the article at a point where I neither knew about Context3D.setDepthTest() (A question on StackOverflow yielded no answer) nor about the renderOrderID in MaterialBase.

I will write an update about this on my blog.
