### PR TITLE
typo _listenToRotationChanged

### DIFF
--- a/src/away3d/core/base/Object3D.as
+++ b/src/away3d/core/base/Object3D.as
@@ -146,7 +146,7 @@ package away3d.core.base
 					_listenToRotationChanged = true;
 					break;
 				case Object3DEvent.SCALE_CHANGED:
-					_listenToRotationChanged = true;
+					_listenToScaleChanged = true;
 					break;
 			}
 		}


### PR DESCRIPTION
fixed typo `_listenToRotationChanged` to `_listenToScaleChanged` when `Object3DEvent.SCALE_CHANGED`